### PR TITLE
@uppy/thumbnail-generator : Fix code crashing in strict mode by using Number constructor

### DIFF
--- a/packages/@uppy/thumbnail-generator/src/exif.js
+++ b/packages/@uppy/thumbnail-generator/src/exif.js
@@ -456,7 +456,7 @@ function readTagValue (file, entryOffset, tiffStart, dirStart, bigEnd) {
       if (numValues === 1) {
         numerator = file.getUint32(valueOffset, !bigEnd)
         denominator = file.getUint32(valueOffset + 4, !bigEnd)
-        val = +(numerator / denominator)
+        val = new Number(numerator / denominator)
         val.numerator = numerator
         val.denominator = denominator
         return val
@@ -465,7 +465,7 @@ function readTagValue (file, entryOffset, tiffStart, dirStart, bigEnd) {
         for (n = 0; n < numValues; n++) {
           numerator = file.getUint32(valueOffset + 8 * n, !bigEnd)
           denominator = file.getUint32(valueOffset + 4 + 8 * n, !bigEnd)
-          vals[n] = +(numerator / denominator)
+          vals[n] = new Number(numerator / denominator)
           vals[n].numerator = numerator
           vals[n].denominator = denominator
         }


### PR DESCRIPTION
In the `1.5.1` release of `@uppy/thumbnail-generator`, some code crashes when in strict mode.

You can see the error here : https://codesandbox.io/s/uppy-exif-strict-issue-y2uzz

I fixed it by putting back the code lines used in the project https://github.com/exif-js/exif-js :
* https://github.com/exif-js/exif-js/blob/master/exif.js#L631
* https://github.com/exif-js/exif-js/blob/master/exif.js#L640
